### PR TITLE
Now capturing bytes read by `readline`, `readexactly` and `readuntil`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,8 @@ refresh_venv: .make/venv_refreshed
 
 .PHONY: test
 test: refresh_venv
-	build_scripts/run_tests.sh --log-cli-level INFO tests
+	#build_scripts/run_tests.sh --log-cli-level INFO tests
+	build_scripts/run_tests.sh tests
 	#build_scripts/run_tests.sh --log-cli-level DEBUG tests/test_mocktcp.py::test_no_remaining_sent_data
 
 .PHONY: testlf

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pytest-mocktcp"
-version = "0.1.16"
+version = "0.1.17"
 license.file = "LICENSE"
 authors = [
     { name="Anders Lindstrom", email="anders@anderslindstrom.com"},


### PR DESCRIPTION
Previously, only bytes read by `reader.read` were captured. Now the other methods are dealt with correctly.

Bumped minor version