### PR TITLE
New tests and code changes to accomodate them

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,7 @@ refresh_venv: .make/venv_refreshed
 
 .PHONY: test
 test: refresh_venv
-	build_scripts/run_tests.sh --log-cli-level DEBUG tests
-	#build_scripts/run_tests.sh --log-cli-level DEBUG tests/pytest_mocktcp/test_plugin.py::test_sent_frame_not_read_by_client
+	build_scripts/run_tests.sh tests
 
 .PHONY: testlf
 testlf: refresh_venv

--- a/build_scripts/run_tests.sh
+++ b/build_scripts/run_tests.sh
@@ -14,6 +14,10 @@ export COV_CORE_SOURCE=src
 export COV_CORE_CONFIG=.coveragerc
 export COV_CORE_DATAFILE=.coverage.eager
 
+coverage erase
+
+# Have to use --cov-append here. See https://pytest-cov.readthedocs.io/en/latest/plugins.html
+
 python -m pytest \
     --log-cli-format "[%(asctime)s.%(msecs)s][%(name)s][%(funcName)s]: %(message)s" \
     --cov src --cov-report term-missing \

--- a/src/pytest_mocktcp/framing.py
+++ b/src/pytest_mocktcp/framing.py
@@ -1,3 +1,4 @@
+import asyncio
 import struct
 
 

--- a/tests/pytest_mocktcp/test_framing.py
+++ b/tests/pytest_mocktcp/test_framing.py
@@ -20,3 +20,7 @@ async def test_framing(tcpserver):
 
     writer.close()
     await writer.wait_closed()
+
+    # After the connection is closed, `read_frame` should return an empty bytes
+    assert await read_frame(reader) == b""
+    assert await read_frame(reader) == b""

--- a/tests/pytest_mocktcp/test_plugin.py
+++ b/tests/pytest_mocktcp/test_plugin.py
@@ -11,6 +11,17 @@ logger = logging.getLogger(__name__)
 
 
 @pytest.mark.asyncio()
+async def test_null_test(tcpserver):
+
+    tcpserver.expect_disconnect()
+    with pytest.raises(
+        Exception,
+        match=r"^Client is not connected. Did you forget to call `asyncio.open_connection`\?$"
+    ):
+        await tcpserver.join()
+
+
+@pytest.mark.asyncio()
 async def test_expect_connect_passes_1(tcpserver):
 
     reader, writer = await asyncio.open_connection(None, tcpserver.service_port)


### PR DESCRIPTION
* `test_framing.py` now covers case of closed connection
* Aded `test_plugin.py::test_null_test`

Also, `run_tests.sh` now erases coverage